### PR TITLE
Rearrange safety checks and return 1 on error

### DIFF
--- a/fp.sh
+++ b/fp.sh
@@ -2,15 +2,15 @@
 #AUTHOR: David Lopez Jr. /* git(hub|lab).com/dlopezjr */
 #PURPOSE: Frontend wrapper for $(flatpak run)
 
-#VARIABLE(S)
-app=$(flatpak list --app | cut -f2 | awk -F. -v app="$1" '(tolower($NF) ~ tolower(app))')
-
 #FUNCTION(S)
 ##check if flatpak is installed and accesible to $PATH
-command -v flatpak || printf "Flatpak package was not found.\n";
+command -v flatpak || { printf "Flatpak package was not found.\n"; exit 1; }
 
 ##check if app name was NOT entered by user
-test -z $1 && printf "Enter an app to fp.\n\$ fp <app>\n\nINSTALLED APPS\n$app\n" && exit; 
+test -z $1 && printf "Enter an app to fp.\n\$ fp <app>\n\nINSTALLED APPS\n$app\n" && exit 1;
+
+#VARIABLE(S)
+app=$(flatpak list --app | cut -f2 | awk -F. -v app="$1" '(tolower($NF) ~ tolower(app))')
 
 ##remove app name from "$@" array
 shift 1;


### PR DESCRIPTION
Rearrange the logic to check for flatpak before continuing. This change also moves the check for any args up before trying to set `app`. As these are errors the script now exits if either check fails with a return code of 1.